### PR TITLE
Improve chain matching

### DIFF
--- a/lib/acme/client/chain_identifier.rb
+++ b/lib/acme/client/chain_identifier.rb
@@ -4,16 +4,30 @@ class Acme::Client
       @pem_certificate_chain = pem_certificate_chain
     end
 
-    def match_name?(name)
-      issuers.any? do |issuer|
-        issuer.include?(name)
+    def match?(name: nil, fingerprint: nil)
+      if fingerprint
+        match_fingerprint?(fingerprint.downcase)
+      elsif name
+        match_name?(name)
       end
+    end
+
+    def match_name?(name)
+      issuers.last.include?(name)
+    end
+
+    def match_fingerprint?(fingerprint)
+      sha256_fingerprints.include?(fingerprint)
     end
 
     private
 
     def issuers
       x509_certificates.map(&:issuer).map(&:to_s)
+    end
+
+    def sha256_fingerprints
+      x509_certificates.map(&:to_der).map { |der| OpenSSL::Digest::SHA256.new(der).to_s }
     end
 
     def x509_certificates

--- a/spec/chain_identifier_spec.rb
+++ b/spec/chain_identifier_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Acme::Client::ChainIdentifier do
   let(:pem) { open('./spec/fixtures/certificate_chain.pem').read }
   let(:issuer_name) { 'Pebble Root CA' }
+  let(:issuer_fingerprint) { '508494af86890199b188befb827c75ae97538272e8dba4c27852b4ce8b96b248' }
 
   subject { Acme::Client::ChainIdentifier.new(pem) }
   it 'matches certificate by name' do
@@ -11,5 +12,24 @@ describe Acme::Client::ChainIdentifier do
 
   it 'fail non matching certificate name' do
     expect(subject).not_to be_a_match_name('foo')
+  end
+
+  it 'matches certificate by fingerprint' do
+    expect(subject).to be_a_match_fingerprint(issuer_fingerprint)
+  end
+
+  it 'fail non matching certificate fingerprint' do
+    expect(subject).not_to be_a_match_fingerprint('foo')
+  end
+
+  describe '#match?' do
+    it 'routes to correct method by argument' do
+      expect(subject).to be_a_match(name: issuer_name)
+      expect(subject).to be_a_match(fingerprint: issuer_fingerprint)
+    end
+
+    it 'gives fingerprint precedence' do
+      expect(subject).to be_a_match(name: 'foo', fingerprint: issuer_fingerprint)
+    end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -238,7 +238,8 @@ describe Acme::Client do
 
             order = client.finalize(url: finalize_url, csr: csr)
             finalized_order = client.order(url: order.url)
-            certificate = client.certificate(url: finalized_order.certificate_url, force_chain: 'Pebble Root CA')
+            fingerprint = '508494af86890199b188befb827c75ae97538272e8dba4c27852b4ce8b96b248'
+            certificate = client.certificate(url: finalized_order.certificate_url, force_chain_fingerprint: fingerprint)
 
             expect { OpenSSL::X509::Certificate.new(certificate) }.not_to raise_error
           end


### PR DESCRIPTION
Two improvements:

- on match_name, we care about the LAST issuer in the chain
- added match_fingerprint so we can be explicit about the issuer we want in our chain without fear of clashing names