### PR TITLE
Travis -> GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    name: Test Ruby ${{ matrix.RUBY_VERSION }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        RUBY_VERSION: ["2.2", "2.6.6"]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Run Tests
+        run: bundle exec rake
+
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Final Results
+    needs: [test]
+    steps:
+      - run: exit 1
+        # see https://stackoverflow.com/a/67532120/4907315
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+# We have a PR to merge from upstream, which has alrady migrated to GHA
+# https://github.com/aptible/acme-client/pull/8
 
 on:
   pull_request:
@@ -17,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        RUBY_VERSION: ["2.2", "2.6.6"]
+        RUBY_VERSION: ["2.6"]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -27,6 +29,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.RUBY_VERSION }}
           bundler-cache: true
+          bundler: 1.17.3
 
       - name: Run Tests
         run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: ruby
-cache: bundler
-rvm:
-  - 2.2
-  - 2.6.6


### PR DESCRIPTION
*shrug* on why there's a test that fails in GHA that doesn't in Travis, but upstream has already migrated to GHA, so when we're ready (??) to pull in from upstream, we'll be able to use their maintained tests: https://github.com/aptible/acme-client/pull/8

https://app.shortcut.com/aptible/story/26219/gha-migration-acme-client